### PR TITLE
Update load_from_file docstring

### DIFF
--- a/logic.py
+++ b/logic.py
@@ -133,7 +133,9 @@ class MemoManager:
     def load_from_file(self, file_path: str) -> None:
         """
         XMLファイルからメモを読み込む
-        
+
+        既存のメモはすべて削除され、読み込んだメモには0から順にIDが再割り当てされる。
+
         Args:
             file_path (str): 読み込むファイルのパス
         """


### PR DESCRIPTION
## Summary
- clarify that memo list is cleared and IDs are reset when loading

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68415ad2c0bc8327a463911678d7fa06